### PR TITLE
Tweak helm chart, improve postgres URI handling

### DIFF
--- a/charts/tdw-server/Chart.yaml
+++ b/charts/tdw-server/Chart.yaml
@@ -3,8 +3,8 @@ name: trustdidweb-server-py
 icon: https://identity.foundation/trustdidweb/tdw.jpg
 description: An api server to register and serve trusted web dids.
 type: application
-version: 0.0.8
-appVersion: "0.0.5"
+version: 0.0.9
+appVersion: "0.0.6"
 
 maintainers:
   - name: PatStLouis

--- a/charts/tdw-server/templates/server/deployment.yaml
+++ b/charts/tdw-server/templates/server/deployment.yaml
@@ -46,8 +46,8 @@ spec:
                   key: password
             - name: POSTGRES_SERVER_NAME
               value: {{ include "global.postgresql.fullname" . }}
-            - name: POSTGRES_SERVER_PASSWORD
-              value: {{ .Values.postgresql.primary.service.ports.postgresql }}
+            - name: POSTGRES_SERVER_PORT
+              value: {{ .Values.postgresql.primary.service.ports.postgresql | quote }}
           ports:
             - name: api
               containerPort: {{ .Values.server.service.apiPort }}

--- a/charts/tdw-server/templates/server/deployment.yaml
+++ b/charts/tdw-server/templates/server/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "server.fullname" . }}
-                  key: SECRET_KEY
+                  key: secret-key
             - name: DOMAIN
               value: {{ .Values.server.host }}
             - name: ENDORSER_MULTIKEY

--- a/charts/tdw-server/templates/server/deployment.yaml
+++ b/charts/tdw-server/templates/server/deployment.yaml
@@ -33,17 +33,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "server.fullname" . }}
                   key: SECRET_KEY
+            - name: DOMAIN
+              value: {{ .Values.server.host }}
+            - name: ENDORSER_MULTIKEY
+              value: {{ .Values.server.environment.ENDORSER_MULTIKEY }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.postgresql.nameOverride }}
                   key: password
-            - name: DOMAIN
-              value: {{ .Values.server.host }}
-            - name: ENDORSER_MULTIKEY
-              value: {{ .Values.server.environment.ENDORSER_MULTIKEY }}
-            - name: POSTGRES_URI
-              value: postgres://{{ .Values.postgresql.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.primary.service.ports.postgresql }}
+            - name: POSTGRES_SERVER_NAME
+              value: {{ include "global.postgresql.fullname" . }}
+            - name: POSTGRES_SERVER_PASSWORD
+              value: {{ .Values.postgresql.primary.service.ports.postgresql }}
           ports:
             - name: api
               containerPort: {{ .Values.server.service.apiPort }}

--- a/charts/tdw-server/templates/server/ingress.yaml
+++ b/charts/tdw-server/templates/server/ingress.yaml
@@ -4,17 +4,21 @@ kind: Ingress
 metadata:
   name: {{ include "server.fullname" . }}
   labels:
+    {{- if .Values.ingress.labels }}  
     {{- toYaml .Values.ingress.labels | nindent 4 }}
+    {{- end }}
     {{- include "server.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.tls }}
   tls:
-  - hosts:
+    - hosts:
       - {{ .Values.server.host | quote }}
     secretName: {{ .Values.fullnameOverride }}-tls
+  {{- end }}
   rules:
   - host: {{ .Values.server.host | quote }}
     http:

--- a/charts/tdw-server/templates/server/ingress.yaml
+++ b/charts/tdw-server/templates/server/ingress.yaml
@@ -4,8 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "server.fullname" . }}
   labels:
-    {{- toYaml .Values.server.labels | nindent 4 }}
+    {{- toYaml .Values.ingress.labels | nindent 4 }}
     {{- include "server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   tls:
   - hosts:

--- a/charts/tdw-server/templates/server/secret.yaml
+++ b/charts/tdw-server/templates/server/secret.yaml
@@ -10,4 +10,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  SECRET_KEY: {{ include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" (include "server.fullname" .) "Key" "SECRET_KEY" "Length" 32) }}
+  secret-key: {{ include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" (include "server.fullname" .) "Key" "secret-key" "Length" 32) }}

--- a/charts/tdw-server/values.yaml
+++ b/charts/tdw-server/values.yaml
@@ -1,11 +1,11 @@
 ---
 nameOverride: "tdw-server"
 fullnameOverride: "tdw-server"
-ingressSuffix: ""
 
 selectorLabels: {}
 
 ingress:
+  tls: false
   labels: []
   annotations: []
 
@@ -19,6 +19,8 @@ server:
     tag: pre-0.0.11
     pullPolicy: IfNotPresent
     pullSecrets: []
+  # host is required when enabling TLS in the ingress
+  # host: server.myapp.example
 
   environment:
     ENDORSER_MULTIKEY: ""

--- a/charts/tdw-server/values.yaml
+++ b/charts/tdw-server/values.yaml
@@ -16,6 +16,7 @@ networkPolicy:
 server:
   image:
     repository: ghcr.io/decentralized-identity/trustdidweb-server-py
+    tag: pre-0.0.11
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/server/config.py
+++ b/server/config.py
@@ -17,10 +17,10 @@ class Settings(BaseSettings):
     DID_WEB_BASE: str = f"did:web:{DOMAIN}"
     ENDORSER_MULTIKEY: str = os.environ["ENDORSER_MULTIKEY"]
 
-    POSTGRES_USER: str = os.environ["POSTGRES_USER"]
-    POSTGRES_PASSWORD: str = os.environ["POSTGRES_PASSWORD"]
-    POSTGRES_SERVER_NAME: str = os.environ["POSTGRES_SERVER_NAME"]
-    POSTGRES_SERVER_PORT: str = os.environ["POSTGRES_SERVER_PORT"]
+    POSTGRES_USER: str = os.getenv("POSTGRES_USER", "")
+    POSTGRES_PASSWORD: str = os.getenv("POSTGRES_PASSWORD", "")
+    POSTGRES_SERVER_NAME: str = os.getenv("POSTGRES_SERVER_NAME", "")
+    POSTGRES_SERVER_PORT: str = os.getenv("POSTGRES_SERVER_PORT", "")
 
     ASKAR_DB: str = "sqlite://app.db"
     if (
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
             f"Using postgres storage: {POSTGRES_SERVER_NAME}:{POSTGRES_SERVER_PORT}"
         )
         ASKAR_DB: str = (
-            f"postgres://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_SERVER_NAME}:{POSTGRES_SERVER_PORT}"
+            f"postgres://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_SERVER_NAME}:{POSTGRES_SERVER_PORT}/tdw-server"
         )
     else:
         logging.info("Using SQLite database")

--- a/server/config.py
+++ b/server/config.py
@@ -1,6 +1,7 @@
 from pydantic_settings import BaseSettings
 import os
 from dotenv import load_dotenv
+import logging
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 load_dotenv(os.path.join(basedir, ".env"))
@@ -16,12 +17,28 @@ class Settings(BaseSettings):
     DID_WEB_BASE: str = f"did:web:{DOMAIN}"
     ENDORSER_MULTIKEY: str = os.environ["ENDORSER_MULTIKEY"]
 
-    ASKAR_DB: str = (
-        os.environ["POSTGRES_URI"]+'/tdw-server'
-        if "POSTGRES_URI" in os.environ
-        else "sqlite://app.db"
-    )
-    SCID_PLACEHOLDER: str = '{SCID}'
+    POSTGRES_USER: str = os.environ["POSTGRES_USER"]
+    POSTGRES_PASSWORD: str = os.environ["POSTGRES_PASSWORD"]
+    POSTGRES_SERVER_NAME: str = os.environ["POSTGRES_SERVER_NAME"]
+    POSTGRES_SERVER_PORT: str = os.environ["POSTGRES_SERVER_PORT"]
+
+    ASKAR_DB: str = "sqlite://app.db"
+    if (
+        POSTGRES_USER
+        and POSTGRES_PASSWORD
+        and POSTGRES_SERVER_NAME
+        and POSTGRES_SERVER_PORT
+    ):
+        logging.info(
+            f"Using postgres storage: {POSTGRES_SERVER_NAME}:{POSTGRES_SERVER_PORT}"
+        )
+        ASKAR_DB: str = (
+            f"postgres://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_SERVER_NAME}:{POSTGRES_SERVER_PORT}"
+        )
+    else:
+        logging.info("Using SQLite database")
+
+    SCID_PLACEHOLDER: str = "{SCID}"
 
 
 settings = Settings()


### PR DESCRIPTION
I've moved the postgresql URI generation to the application, as it makes it simpler for the chart to inject a value from a secret without having to build a helper (and exposing the secret in plaintext in the pod YAML). This required minor code changes to `config.py`.

Improved handling of ingress and related TLS settings.