### PR TITLE
Change booleans to strings in policy env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,26 +48,26 @@ When a rule is enforced, the server will reject any request that doesn't match s
 #### Known Witnesses Registry
 
 - WEBVH_KNOWN_WITNESS_KEY: A default known witness key to provision the server.
-    - ex: `WEBVH_KNOWN_WITNESS_KEY=z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP`
+    - ex: `WEBVH_KNOWN_WITNESS_KEY="z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"`
 
 - WEBVH_KNOWN_WITNESS_REGISTRY: A list of known witnesses is used for validating witness policies. This will be cached every time a witness can't be found.
-    - ex: `WEBVH_KNOWN_WITNESS_REGISTRY=https://known-witnesses.example.com`
+    - ex: `WEBVH_KNOWN_WITNESS_REGISTRY="https://known-witnesses.example.com"`
 
 #### Attested Resource Endorsement
 
 - WEBVH_ENDORSEMENT: This will require a known witness proof on any attested resource uploaded or updated. It's up to the witness service to determine which resources to endorse from the controller.
-    - ex: `WEBVH_ENDORSEMENT=true`
+    - ex: `WEBVH_ENDORSEMENT="true"`
 
 #### WebVH Parameters
 
 The following policy variables can be used to enforce parameters from the did:webvh specification:
 - WEBVH_VERSION: Specify a webvh method version to enforce
-    - ex: `WEBVH_VERSION=1.0`
+    - ex: `WEBVH_VERSION="1.0"`
 - WEBVH_WITNESS: Enforce the use of witness with a minimum threshold of 1. At least 1 witness from the known witness registry will need to be used.
-    - ex: `WEBVH_WITNESS=true`
+    - ex: `WEBVH_WITNESS="true"`
 - WEBVH_PORTABILITY: Ensure that portability is enabled.
-    - ex: `WEBVH_PORTABILITY=true`
+    - ex: `WEBVH_PORTABILITY="true"`
 - WEBVH_WATCHER: Request a specific watcher to be included in the watchers array
     - ex: `WEBVH_WATCHER=https://watcher.example.com`
 - WEBVH_PREROTATION: Enforce the use of prerotation
-    - ex: `WEBVH_PREROTATION=true`
+    - ex: `WEBVH_PREROTATION="true"`

--- a/charts/didwebvh-server/Chart.yaml
+++ b/charts/didwebvh-server/Chart.yaml
@@ -3,8 +3,8 @@ name: didwebvh-server-py
 icon: https://identity.foundation/didwebvh/didwebvh.jpg
 description: An api server to register and serve web dids with verifiable history.
 type: application
-version: 0.3.0
-appVersion: 0.3.0
+version: 0.3.1
+appVersion: 0.3.1
 
 maintainers:
   - name: PatStLouis

--- a/charts/didwebvh-server/templates/server/configmap.yaml
+++ b/charts/didwebvh-server/templates/server/configmap.yaml
@@ -8,21 +8,23 @@ metadata:
   labels:
     {{- include "server.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
-type: Opaque
 data:
-  DOMAIN: {{ .Values.server.host }}
-  APP_PORT: {{ .Values.server.service.apiPort }}
-  {{ if .Values.server.workers }}
-  APP_WORKERS: {{ .Values.server.workers }}{{ end }}
-  {{ if .Values.server.known_witness_key }}
-  KNOWN_WITNESS_KEY: {{ .Values.server.known_witness_key }}{{ end }}
-  {{ if .Values.server.known_witness_registry }}
-  KNOWN_WITNESS_REGISTRY: {{ .Values.server.known_witness_registry }}{{ end }}
-  {{ if .Values.server.policies }}
+  DOMAIN: {{ .Values.server.host | quote }}
+  APP_PORT: {{ .Values.server.service.apiPort | quote }}
+  {{- if .Values.server.workers }}
+  APP_WORKERS: {{ .Values.server.workers }}
+  {{- end }}
+  {{- if .Values.server.known_witness_key }}
+  KNOWN_WITNESS_KEY: {{ .Values.server.known_witness_key | quote }}
+  {{- end }}
+  {{- if .Values.server.known_witness_registry }}
+  KNOWN_WITNESS_REGISTRY: {{ .Values.server.known_witness_registry | quote }}
+  {{- end }}
+  {{- if .Values.server.policies }}
   WEBVH_VERSION: {{ .Values.server.policies.webvh_version | default "1.0" | quote }}
-  WEBVH_WITNESS: {{ .Values.server.policies.webvh_witness | default false }}
+  WEBVH_WITNESS: {{ .Values.server.policies.webvh_witness | default "false" | quote }}
   WEBVH_WATCHER: {{ .Values.server.policies.webvh_watcher | default "" | quote }}
-  WEBVH_PREROTATION: {{ .Values.server.policies.webvh_prerotation | default false }}
-  WEBVH_PORTABILITY: {{ .Values.server.policies.webvh_portability | default false }}
-  WEBVH_ENDORSEMENT: {{ .Values.server.policies.webvh_endorsement | default false }}
-  {{ end }}
+  WEBVH_PREROTATION: {{ .Values.server.policies.webvh_prerotation | default "false" | quote }}
+  WEBVH_PORTABILITY: {{ .Values.server.policies.webvh_portability | default "false" | quote }}
+  WEBVH_ENDORSEMENT: {{ .Values.server.policies.webvh_endorsement | default "false" | quote }}
+  {{- end }}

--- a/charts/didwebvh-server/templates/server/deployment.yaml
+++ b/charts/didwebvh-server/templates/server/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           envFrom:
             - configMapRef:
-              name: {{ include "server.fullname" . }}
+                name: {{ include "server.fullname" . }}
           env:
             - name: API_KEY
               valueFrom:

--- a/charts/didwebvh-server/values.yaml
+++ b/charts/didwebvh-server/values.yaml
@@ -19,19 +19,19 @@ server:
     tag: 0.2.0
     pullPolicy: IfNotPresent
     pullSecrets: []
-    default_witness_key: null
 
   host: example.com
 
-  workers: 4
+  workers: "4"
 
+  # Policies should be configured according to governance decisions
   policies:
     webvh_version: "1.0"
-    webvh_witness: true
-    webvh_watcher: null
-    webvh_prerotation: true
-    webvh_portability: true
-    webvh_endorsement: true
+    webvh_witness: "true"
+    webvh_watcher: ""
+    webvh_prerotation: "true"
+    webvh_portability: "true"
+    webvh_endorsement: "true"
 
   replicaCount: 1
 

--- a/server/config.py
+++ b/server/config.py
@@ -46,11 +46,11 @@ class Settings(BaseSettings):
     KNOWN_WITNESS_REGISTRY: Union[str, None] = os.environ.get("KNOWN_WITNESS_REGISTRY", None)
 
     WEBVH_VERSION: str = os.environ.get("WEBVH_VERSION", "1.0")
-    WEBVH_WITNESS: bool = os.environ.get("WEBVH_WITNESS", True)
+    WEBVH_WITNESS: bool = eval(os.environ.get("WEBVH_WITNESS", "true").capitalize())
     WEBVH_WATCHER: Union[str, None] = os.environ.get("WEBVH_WATCHER", None)
-    WEBVH_PREROTATION: bool = os.environ.get("WEBVH_PREROTATION", True)
-    WEBVH_PORTABILITY: bool = os.environ.get("WEBVH_PORTABILITY", True)
-    WEBVH_ENDORSEMENT: bool = os.environ.get("WEBVH_ENDORSEMENT", False)
+    WEBVH_PREROTATION: bool = eval(os.environ.get("WEBVH_PREROTATION", "true").capitalize())
+    WEBVH_PORTABILITY: bool = eval(os.environ.get("WEBVH_PORTABILITY", "true").capitalize())
+    WEBVH_ENDORSEMENT: bool = eval(os.environ.get("WEBVH_ENDORSEMENT", "false").capitalize())
 
 
 settings = Settings()

--- a/server/main.py
+++ b/server/main.py
@@ -11,6 +11,6 @@ if __name__ == "__main__":
     uvicorn.run(
         "app:app",
         host="0.0.0.0",
-        port=os.getenv("APP_PORT", 8000),
-        workers=os.getenv("APP_WORKERS", 4),
+        port=int(os.getenv("APP_PORT", "8000")),
+        workers=int(os.getenv("APP_WORKERS", "4")),
     )


### PR DESCRIPTION
Kubernetes environment variables must be strings, adapt codebase to reflect this.